### PR TITLE
fix(optimizeImageTrait): set translator property to protected

### DIFF
--- a/src/OptimizeImageTrait.php
+++ b/src/OptimizeImageTrait.php
@@ -40,7 +40,7 @@ trait OptimizeImageTrait
     /**
      * @var TranslatorInterface
      */
-    private $translator;
+    protected $translator;
 
     /**
      * @param Request|null $request


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - master is for everything backwards compatible, like patches, features and deprecation notices
    - 1.x-dev is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/ekino/tiny-png-sonata-media-bundle/blob/master/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because I have a conflict with sonata AbastractAdmin.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Replace visibility of $translator variable 
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [ ] replace private by protected

## Subject

<!-- Describe your Pull Request content here -->
I have a conflict with visibility of variable $translator in sonata abstact admin class.
