### PR TITLE
fix(optimizeImageAdminExtension): fix type hinting error on configureActionButtons method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ CHANGELOG
 master
 ------
 
+* Fix type hinting error on configureActionButtons method
+
 v1.0.0
 ------
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is a *work in progress*, so if you'd like something implemented please
 feel free to ask for it or contribute to help us!
 
 # Resources
-- [Documentation](./00-docs.md)
+- [Documentation](./docs/00-docs.md)
 
 # Purpose
 

--- a/tests/Admin/Extension/OptimizeImageAdminExtensionTest.php
+++ b/tests/Admin/Extension/OptimizeImageAdminExtensionTest.php
@@ -17,6 +17,7 @@ use Ekino\TinyPngSonataMediaBundle\Admin\Extension\OptimizeImageAdminExtension;
 use PHPUnit\Framework\TestCase;
 use Sonata\AdminBundle\Admin\AdminInterface;
 use Sonata\AdminBundle\Route\RouteCollection;
+use Sonata\MediaBundle\Model\Media;
 
 /**
  * Class OptimizeImageAdminExtensionTest
@@ -43,9 +44,10 @@ class OptimizeImageAdminExtensionTest extends TestCase
      */
     public function testConfigureActionButtons(): void
     {
-        $admin = $this->createMock(AdminInterface::class);
+        $admin  = $this->createMock(AdminInterface::class);
+        $media  = $this->createMock(Media::class);
 
-        $list = $this->optimizeImageAdminExtension->configureActionButtons($admin, [], '', '');
+        $list = $this->optimizeImageAdminExtension->configureActionButtons($admin, [], '', $media);
 
         $this->assertArrayHasKey('custom_action', $list);
         $this->assertArrayHasKey('template', $list['custom_action']);


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - master is for everything backwards compatible, like patches, features and deprecation notices
    - 1.x-dev is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/ekino/tiny-png-sonata-media-bundle/blob/master/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because there are an error analysis on configureActionButtons method.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Fixed
- Fix configureActionButtons method type hinting in OptimizeImageAdminExtension.php
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [x] Fix `configureActionButtons` method type hinting in `OptimizeImageAdminExtension.php`
- [x] Update the tests
## Subject
Fix `configureActionButtons` method type hinting in `OptimizeImageAdminExtension.php`

<!-- Describe your Pull Request content here -->
