### PR TITLE
fix(github): remove link does not work in Github pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,8 +4,6 @@
     Show us you choose the right branch.
     Different branches are used for different things :
     - master is for everything backwards compatible, like patches, features and deprecation notices
-    - 1.x-dev is for deprecation removals and other changes that cannot be done without a BC-break
-    More details here: https://github.com/ekino/tiny-png-sonata-media-bundle/blob/master/CONTRIBUTING.md#the-base-branch
 -->
 I am targeting this branch, because {reason}.
 


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - master is for everything backwards compatible, like patches, features and deprecation notices
    - 1.x-dev is for deprecation removals and other changes that cannot be done without a BC-break
    More details here: https://github.com/ekino/tiny-png-sonata-media-bundle/blob/master/CONTRIBUTING.md#the-base-branch
-->
I am targeting this branch, because CONTRIBUTING.md doesn't work.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->


## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown



### Removed
- Link into PULL_REQUEST_TEMPLATE.md

```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [x] Update the PULL_REQUEST_TEMPLATE.md


## Subject

The https://github.com/ekino/tiny-png-sonata-media-bundle/blob/master/CONTRIBUTING.md#the-base-branch doesn't work into `PULL_REQUEST_TEMPLATE.md`