### PR TITLE
Drop support for PHP 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ branches:
 language: php
 
 php:
-  - '7.1'
   - '7.2'
   - '7.3'
+  - '7.4'
 
 dist: trusty
 sudo: false
@@ -26,24 +26,18 @@ matrix:
     - php: '7.3'
       env: SYMFONY=3.4.*
     - php: '7.3'
-      env: SYMFONY=^4.2
+      env: SYMFONY=^4.4
     - php: '7.3'
       env: SYMFONY_DEPRECATIONS_HELPER=0
     - php: '7.2'
       env: SYMFONY=3.4.*
     - php: '7.2'
-      env: SYMFONY=^4.2
+      env: SYMFONY=^4.4
     - php: '7.2'
-      env: SYMFONY_DEPRECATIONS_HELPER=0
-    - php: '7.1'
-      env: SYMFONY=3.4.*
-    - php: '7.1'
-      env: SYMFONY=^4.2
-    - php: '7.1'
       env: SYMFONY_DEPRECATIONS_HELPER=0
   allow_failures:
     - php: nightly
-    - php: '7.3'
+    - php: '7.4'
     - env: SYMFONY_DEPRECATIONS_HELPER=0
 
 before_install:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ master
 ------
 
 * Fix type hinting error on configureActionButtons method
+* Drop support for PHP 7.1
+* Add PHP 7.4 in CI
+* Upgrade PhpUnit to 8
 
 v1.0.0
 ------

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ app-security-check: ## to check if any security issues in the PHP dependencies
 	vendor/bin/security-checker security:check
 
 app-static-analysis: ## to run static analysis
-	php -dmemory_limit=-1 vendor/bin/phpstan analyze . -l 5
+	php -dmemory_limit=-1 vendor/bin/phpstan analyze . -l 6
 
 app-test: ## to run unit tests
 	vendor/bin/phpunit

--- a/TODO.md
+++ b/TODO.md
@@ -3,12 +3,10 @@ What's next?
 
 - Add unit test on MediaEventSubscriber
 - Add unit test on OptimizeImageConsumerTest
-- Add admin action to launch an optimization from media admin edit
 - Regenerate formats/thumbnails after optimization
 - Handle others kind of adapters than local
 
 Nice to have
 ============
 
-- liip monitor check on tinyPNG API consumption (free token is limited to 500 calls/month)
 - sonata admin block to display the tinyPNG API consumption

--- a/composer.json
+++ b/composer.json
@@ -12,26 +12,25 @@
     }
   ],
   "require": {
-    "php":                                "^7.1",
+    "php":                                "^7.2",
     "doctrine/orm":                       "^2.6",
     "sonata-project/admin-bundle":        "^3.1",
     "sonata-project/media-bundle":        "^3.0",
     "sonata-project/notification-bundle": "^3.1",
-    "symfony/framework-bundle":           "^3.3 || ^4.0",
-    "symfony/translation":                "^3.3 || ^4.0",
+    "symfony/framework-bundle":           "^3.3 || ^4.4",
+    "symfony/translation":                "^3.3 || ^4.4",
     "tinify/tinify":                      "^1.5"
   },
   "conflict": {
-    "sonata-project/admin-bundle": "<3.27",
-    "sonata-project/media-bundle": "<3.0"
+    "sonata-project/admin-bundle": "<3.27"
   },
   "require-dev": {
-    "ekino/phpstan-banned-code":   "^0.1",
+    "ekino/phpstan-banned-code":   "^0.2 || ^0.3",
     "friendsofphp/php-cs-fixer":   "^2.12",
-    "phpstan/phpstan-phpunit":     "^0.11",
-    "phpunit/phpunit":             "^7.2",
-    "sensiolabs/security-checker": "^5.0",
-    "symfony/phpunit-bridge":      "^3.3 || ^4.0"
+    "phpstan/phpstan-phpunit":     "^0.12",
+    "phpunit/phpunit":             "^8.5",
+    "sensiolabs/security-checker": "^6.0",
+    "symfony/phpunit-bridge":      "^5.0"
   },
   "suggest": {
     "liip/monitor-bundle": "^2.9"

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -4,6 +4,7 @@ includes:
 	- vendor/phpstan/phpstan-phpunit/rules.neon
 
 parameters:
+	checkMissingIterableValueType: false
 	excludes_analyse:
 		- %rootDir%/../../../vendor/*
 		- %rootDir%/../../../src/DependencyInjection/Configuration.php

--- a/src/Admin/Extension/OptimizeImageAdminExtension.php
+++ b/src/Admin/Extension/OptimizeImageAdminExtension.php
@@ -41,7 +41,7 @@ final class OptimizeImageAdminExtension extends AbstractAdminExtension
     /**
      * {@inheritdoc}
      */
-    public function configureRoutes(AdminInterface $admin, RouteCollection $collection)
+    public function configureRoutes(AdminInterface $admin, RouteCollection $collection): void
     {
         $collection->add('optimize',
             'optimize-image/{id}',

--- a/src/DependencyInjection/EkinoTinyPngSonataMediaExtension.php
+++ b/src/DependencyInjection/EkinoTinyPngSonataMediaExtension.php
@@ -28,7 +28,7 @@ class EkinoTinyPngSonataMediaExtension extends Extension
     /**
      * {@inheritdoc}
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = new Configuration();
         $config        = $this->processConfiguration($configuration, $configs);


### PR DESCRIPTION
I am targeting this branch, because this is the only one.

## Changelog
```markdown
### Added
- PHP 7.4 in CI

### Changed
- Upgrade PhpUint to 8

### Removed
- Support for PHP 7.1
```