### PR TITLE
chore(phpstan): fix checkGenericClassInNonGenericObjectType to false …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ master
 * Drop support for PHP 7.1
 * Add PHP 7.4 in CI
 * Upgrade PhpUnit to 8
+* Fix checkGenericClassInNonGenericObjectType to false for generic T type from SonataMedia
 
 v1.0.0
 ------

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -5,6 +5,7 @@ includes:
 
 parameters:
 	checkMissingIterableValueType: false
+	checkGenericClassInNonGenericObjectType: false
 	excludes_analyse:
 		- %rootDir%/../../../vendor/*
 		- %rootDir%/../../../src/DependencyInjection/Configuration.php


### PR DESCRIPTION
…for generic T type from SonataMedia

<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - master is for everything backwards compatible, like patches, features and deprecation notices
-->
I am targeting this branch, because {reason}.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #{put_issue_number_here}

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added some `Class::newMethod` to do great stuff

### Changed

### Deprecated

### Removed

### Fixed

### Security
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [ ] Update the tests
- [ ] Update the documentation
- [ ] Add an upgrade note

## Subject

<!-- Describe your Pull Request content here -->
