### PR TITLE
Fix depreciated PHP-CS rules

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -18,51 +18,53 @@ For the full copyright and license information, please view the LICENSE
 file that was distributed with this source code.
 EOF;
 
-return PhpCsFixer\Config::create()
+$finder = PhpCsFixer\Finder::create()
+    ->in(__DIR__)
+    ->in(['src','tests'])
+;
+
+$config = new PhpCsFixer\Config();
+$config->setUsingCache(true)
     ->setRiskyAllowed(true)
-    ->setRules([
-        'array_indentation' => true,
-        'array_syntax' => ['syntax' => 'short'],
-        'binary_operator_spaces' => ['align_double_arrow' => true, 'align_equals' => true],
-        'blank_line_after_namespace' => true,
-        'blank_line_after_opening_tag' => true,
-        'declare_strict_types' => true,
-        'header_comment' => ['header' => $header],
-        'indentation_type' => true,
-        'linebreak_after_opening_tag' => true,
-        'lowercase_constants' => true,
-        'lowercase_keywords' => true,
-        'method_separation' => true,
-        'native_function_invocation' => ['include' => ['@compiler_optimized']],
-        'no_alias_functions' => true,
-        'no_closing_tag' => true,
-        'no_extra_consecutive_blank_lines' => [
-            'tokens' => [
-                'break',
-                'continue',
-                'curly_brace_block',
-                'extra',
-                'parenthesis_brace_block',
-                'return',
-                'square_brace_block',
-                'throw',
-                'use',
-            ],
+    ->setFinder($finder);
+return $config->setRules([
+    'array_indentation' => true,
+    'array_syntax' => ['syntax' => 'short'],
+    'binary_operator_spaces' => ['default' => 'align', 'operators' => ['=>' => 'align', '=' => 'align_single_space']],
+    'blank_line_after_namespace' => true,
+    'blank_line_after_opening_tag' => true,
+    'declare_strict_types' => true,
+    'header_comment' => ['header' => $header],
+    'indentation_type' => true,
+    'linebreak_after_opening_tag' => true,
+    'constant_case' => true,
+    'lowercase_keywords' => true,
+    'native_function_invocation' => ['include' => ['@compiler_optimized']],
+    'no_alias_functions' => true,
+    'no_closing_tag' => true,
+    'no_extra_blank_lines' => [
+        'tokens' => [
+            'break',
+            'continue',
+            'curly_brace_block',
+            'extra',
+            'parenthesis_brace_block',
+            'return',
+            'square_brace_block',
+            'throw',
+            'use',
         ],
-        'no_short_echo_tag' => true,
-        'no_useless_else' => true,
-        'no_unused_imports' => true,
-        'no_useless_return' => true,
-        'ordered_imports' => true,
-        'phpdoc_add_missing_param_annotation' => true,
-        'phpdoc_order' => true,
-        'semicolon_after_instruction' => true,
-        'visibility_required' => true,
-    ])
-    ->setUsingCache(true)
-    ->setFinder(
-        PhpCsFixer\Finder::create()
-            ->in(__DIR__)
-            ->in(['src','tests'])
-    )
+    ],
+    'echo_tag_syntax' => ['format' => 'long'],
+    'no_useless_else' => true,
+    'no_unused_imports' => true,
+    'no_useless_return' => true,
+    'ordered_imports' => false,
+    'phpdoc_add_missing_param_annotation' => true,
+    'phpdoc_order' => true,
+    'semicolon_after_instruction' => true,
+    'visibility_required' => [
+        'elements' => ['method', 'property', 'const']
+    ],
+])
 ;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ master
 * Migrate from Travis to GitHub Actions
 * Allow PHP 8.0
 * Drop support for Symfony 3 and allow version 5
+* Fix depreciated PHP-CS rules
 
 v1.0.0
 ------


### PR DESCRIPTION
<!-- THE PR TEMPLATE IS NOT AN OPTION. DO NOT DELETE IT, MAKE SURE YOU READ AND EDIT IT! -->

<!--
    Show us you choose the right branch.
    Different branches are used for different things :
    - master is for everything backwards compatible, like patches, features and deprecation notices
-->
I am targeting this branch, because I fixed depreciated PHP-CS rules.

<!--
    Specify which issues will be fixed/closed.
    Remove it if this is not related.
-->

Closes #{put_issue_number_here}

## Changelog

<!-- MANDATORY
    Fill the changelog part inside the code block.
    Follow this schema: http://keepachangelog.com/
-->

<!-- REMOVE EMPTY SECTIONS -->
```markdown
### Added
- Added some `Class::newMethod` to do great stuff

### Changed

### Deprecated

### Removed

### Fixed

### Security
```

## To do

<!--
    If this is a work in progress, COMPLETE and ADD needed tasks.
    You can add as many tasks as you want.
    If some are not relevant, just REMOVE them.
-->

- [ ] Update the tests
- [ ] Update the documentation
- [ ] Add an upgrade note

## Subject

<!-- Describe your Pull Request content here -->
